### PR TITLE
FIX: Force pip version to fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ setup.py:
 	@echo 'setup.py created'
 
 publish: setup.py
+	$(PIP) install -U pip
 	$(PYTHON) setup.py sdist bdist_wheel
 	$(TWINE) check dist/*
 	$(TWINE) upload dist/*


### PR DESCRIPTION
The following error seems to be caused by
a mismatch in pip versions. It looks similar
to: https://github.com/pypa/pip/issues/5373

    kpnnv/katka-core make publish
    "python3.8" setup_gen.py
    Traceback (most recent call last):
      File "/usr/local/lib/python3.8/site-packages/pkgversion/pkgversion.py", line 8, in <module>
        from pip._internal.download import PipSession
    ModuleNotFoundError: No module named 'pip._internal.download'

To prevent this from happening, we upgrade to the
newest pip.